### PR TITLE
Allow for sub declarations to be multi-line (distinguished with { or ; )

### DIFF
--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -694,8 +694,20 @@ my $file=shift;
 
 
 		if ($line=~ m/^\s*sub [^ ]+/){ ## head line
+			my $analysisLine = $self->_trim($line);
+			if ($line !~ /;|{/) {
+				my $nextIndex = $p + 1;
+				while ($#{$arr} > $nextIndex) {
+					my $nextLine = $arr->[$nextIndex];
+					if ($nextLine =~ /;|{/) {
+						$analysisLine = $self->_trim($line) . $self->_trim($nextLine);
+						last;
+					}
+					$nextIndex++;
+				}
+			}
 			$self->_clearHeadBuffer();
-			$self->_setMethodLine($line);
+			$self->_setMethodLine($analysisLine);
 			$self->{'STATE'} = 'headwait';
 			$self->_addBodyBufferToAttr();
 			$self->_setMethodAttr($self->_getMethodName(),'returnline',$self->_getMethodReturn());


### PR DESCRIPTION
Using perltidy, you might end up with a block like:

```
sub function

{ # void ($text|\@array, $file, $third_arg, $particularly_long_argumentname)
```

As of now, the resulting Pod would be:
`$self->function();`

Instead of:

` $self->function($text | \@array, $file, $third_arg, $particularly_long_argumentname);`
