### PR TITLE
Doxy params

### DIFF
--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -586,6 +586,17 @@ my $self=shift;
 my $arr=shift or die "Arrayref expected";	
 my $file=shift;	
 	$self->{'STATE'} = 'head';
+
+    my %allowed_return_types = (void => '',
+    'array'			=>	'@',
+    'arrayref'	=>	'\@',
+    'hash'			=>	'%',
+    'hashref'		=>	'\%',
+    'method'		=>	'&',
+    'scalar'		=>	'$',
+    'scalarref'	=>	'\$',
+    );
+
 	
 	
 	## reverse read
@@ -615,7 +626,8 @@ my $file=shift;
 						$l =~ m/^([^\s]+)/;
 						my $firstword = $1;
                         $firstword =~ s/[\W]$//; # remove potential trailing punctuation
-						if ($firstword !~ m/^[\$\@\%]/){$firstword='$'.$firstword}; # scalar is fallback if nothing given
+                        # either supplied a var type or a ref to a var type
+						if ($firstword !~ m/(^[\$\@\%]|^\\[\$\@\%])/ && !defined($allowed_return_types{$firstword})){$firstword='$'.$firstword}; # scalar is fallback if nothing given
 						push @param, $firstword;
 					}
 					
@@ -651,7 +663,7 @@ my $file=shift;
 				my $retval = $1;
 				my $desc = $2 || $retval;
 
-				if ($retval !~ m/^[\$\@\%]/){$retval='$'.$retval}; # scalar is fallback if nothing given
+				if ($retval !~ m/(^[\$\@\%]|^\\[\$\@\%])/ && !defined($allowed_return_types{$retval})){$retval='$'.$retval}; # scalar is fallback if nothing given
 
 				if (exists $self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'returnline'}){
 					$self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'methodlinerest'} =~ s/(\s*\#\s*)([^\s]+) /$1$retval/;	# remove/replace value behind "sub {" declaration

--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -685,6 +685,16 @@ my $file=shift;
                 # because this file is read from the bottom up, we need to reverse the read parameter order
 				unshift @{ $self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'doxyparamline'} }, $text if $self->_trim($text) ne '';
 			}
+
+            # allow custom on-the-fly parameters by using a ! after @
+            if ($line=~ m/^\s*#\s*\@!(.*?)\s+(.*)/){
+				my $text = $1 . ': ' . $2;
+				$self->_addLineToHeadBuffer("");
+				$self->_addLineToHeadBuffer($text);
+				$self->_addLineToHeadBuffer("");
+				$writeOut = 0;
+			}
+
 		}
 
 

--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -614,6 +614,7 @@ my $file=shift;
 					foreach my $l (@{ $self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'doxyparamline'} }){
 						$l =~ m/^([^\s]+)/;
 						my $firstword = $1;
+                        $firstword =~ s/[\W]$//; # remove potential trailing punctuation
 						if ($firstword !~ m/^[\$\@\%]/){$firstword='$'.$firstword}; # scalar is fallback if nothing given
 						push @param, $firstword;
 					}
@@ -680,9 +681,10 @@ my $file=shift;
 				$writeOut = 0;
 
 				$self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'doxyparamline'} ||= [];
-				push @{ $self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'doxyparamline'} }, $text;
-			}
 
+                # because this file is read from the bottom up, we need to reverse the read parameter order
+				unshift @{ $self->{'METHOD_ATTR'}->{ $self->_getMethodName() }->{'doxyparamline'} }, $text if $self->_trim($text) ne '';
+			}
 		}
 
 

--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -694,8 +694,20 @@ my $file=shift;
 
 
 		if ($line=~ m/^\s*sub [^ ]+/){ ## head line
+			my $analysisLine = $self->_trim($line);
+			if ($line !~ /;|{/) {
+				my $nextIndex = $p + 1;
+				while ($#{$arr} > $nextIndex) {
+					my $nextLine = $arr->[$nextIndex];
+					if ($nextLine =~ /;|{/) {
+						$analysisLine = $self->_trim($line) . $self->_trim($nextLine);
+						last;
+					}
+					$nextIndex++;
+				}
+			}
 			$self->_clearHeadBuffer();
-			$self->_setMethodLine($line);
+			$self->_setMethodLine($analysisLine);
 			$self->{'STATE'} = 'headwait';
 			$self->_addBodyBufferToAttr();
 			$self->_setMethodAttr($self->_getMethodName(),'returnline',$self->_getMethodReturn());


### PR DESCRIPTION
I made the doxy handling a bit more flexible for `@param`s.

Because it reads the head in reverse, if there are multiple @param lines, they'll be displayed inline in reverse, so:

```
@param arg1
@param arg2
```

would render as

`(arg2, arg1)`.

Also, this is now supported:

```
# @param arg1, required
# @param arg2, optional
```
yielding
`(arg1, arg2)`.

Perhaps some indicator for required/optional should be added?

=========

Also, I added support for flexible doxy parameters.

`# @!FIRST_WORD random text`

now comes out as:

`FIRST_WORD: random text`

The `@!` is the sigil