### PR TITLE
Custom multiline examples

### DIFF
--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -724,9 +724,9 @@ my $file=shift;
 			my $multiline_close = '*@';
 			if ($line =~ /\s*#.*\Q$multiline_close\E$/) {
 				my $amalgamation = $line;
-				$amalgamation =~ s/\Q$multiline_close\E$//;
+				$amalgamation =~ s/\s*\Q$multiline_close\E$//;
 				$amalgamation =~ s/\n//;
-				$amalgamation =~ s/^#/ /;
+				$amalgamation =~ s/^#/   /;
 
 				# because we're looking at the closing line first, we need to subtract from the current index
 				# to find the opening line
@@ -737,15 +737,16 @@ my $file=shift;
 					push (@skipLines, $nextIndex);
 
 					my $line_without_markers = $nextLine;
-					$line_without_markers =~ s/^\#//;
+					$line_without_markers =~ s/^\#/   /;
 					$line_without_markers =~ s/\n$//;
-					if ($nextLine =~ m/^\s*#\s*\Q$multiline_open\E(.*?)\s+(.*)/) {
-						my $keyword = $1;
+					if ($nextLine =~ m/^\s*#(\s*)\Q$multiline_open\E(.*?)\s+(.*)/) {
+						my $keyword = $2;
 						$keyword =~ s/\Q$multiline_open\E//;
-						$amalgamation = $keyword . ' ' . $2 . "\n" . $amalgamation;
+						$amalgamation = $keyword . ' ' . $3 . "\n\r" . $amalgamation;
+						$amalgamation =~ s/\n\r/\n\r$1   /gm; # add 3 spaces because @* and # all change alignment parameters
 						last;
 					} else {
-						$amalgamation = $line_without_markers . "\n" . $amalgamation;
+						$amalgamation = $line_without_markers . "\n\r" . $amalgamation;
 					}
 					$nextIndex--;
 				}

--- a/lib/Pod/Autopod.pm
+++ b/lib/Pod/Autopod.pm
@@ -168,9 +168,10 @@ use Pod::Abstract::BuildNode qw(node nodes);
 #
 # Added some hacks to teach this tool also some doxygen parametes. For example:
 #
-#  # @brief  kept as simple text
-#  # @param  text to be added
-#  # @return string with some text
+#  # @brief   kept as simple text
+#  # @param   text to be added
+#  # @return  string with some text
+#  # @!CUSTOM any custom text (the ! is the trigger for the custom code)
 #  sub foo{
 #    return "abc".shift;
 #  }
@@ -756,25 +757,25 @@ my $file=shift;
 			$self->{'PKGNAME_DESC'}=~ s/^\s*\#*//g;
 		}
 
-		if ($line=~ m/^\s*use +([^\; ]+)[\; ](.*)/){
+		if ($line=~ m/^\s*(use|require) +([^\; ]+)[\; ](.*)/){
 			$self->{'REQUIRES'} = $self->{'REQUIRES'} || [];
-			my $name=$1;
-			my $rem=$2;
+			my $name=$2;
+			my $rem=$3;
 			$rem=~ s/^[^\#]*\#*//;
-			push @{$self->{'REQUIRES'}},{'name'=>$name,'desc'=>$rem};
+			unshift @{$self->{'REQUIRES'}},{'name'=>$name,'desc'=>$rem};
 		}
 
 
-		if (($line=~ m/^\s*use base +([^\; ]+)[\;](.*)/) ||
+		if (($line=~ m/^\s*(use|require) base +([^\; ]+)[\;](.*)/) ||
 			($line=~ m/^\s*our +\@ISA +([^\; ]+)[\;](.*)/)){
 			$self->{'INHERITS_FROM'} = $self->{'INHERITS_FROM'} || [];
-			my $name=$1;
-			my $rem=$2;
+			my $name=$2;
+			my $rem=$3;
 			$name=~ s/qw\(//g;
 			$name=~ s/[\)\']//g;
 			my @n=split(/ +/,$name);
 			foreach my $n (@n){
-				push @{$self->{'INHERITS_FROM'}},{'name'=>$n} if $n;	
+				unshift @{$self->{'INHERITS_FROM'}},{'name'=>$n} if $n;	
 			}
 		}
 		
@@ -1905,9 +1906,10 @@ example LICENSE is allways near the end.
 
 Added some hacks to teach this tool also some doxygen parametes. For example:
 
- # @brief  kept as simple text
- # @param  text to be added
- # @return string with some text
+ # @brief   kept as simple text
+ # @param   text to be added
+ # @return  string with some text
+ # @!CUSTOM any custom text (the ! is the trigger for the custom code)
  sub foo{
    return "abc".shift;
  }


### PR DESCRIPTION
Added @* ... *@ command to allow for multi-line doxygen style parameters.  I think this helps for clarity when using doxygen and needing to document parameters that might be complex, like:

```
     # @*MULTILINE_EXAMPLE func1 arg1 END
     #                     func2      END
     #                     func3 arg2 END *@
```

Fixed some issues with spacing so that the #@* counts as 3 spaces for multi-line alignment so it displays in POD aligned as it would in the comments.